### PR TITLE
Change pathing to unscaledTime

### DIFF
--- a/CameraTools/CamTools.cs
+++ b/CameraTools/CamTools.cs
@@ -227,7 +227,7 @@ namespace CameraTools
 		{
 			get
 			{
-				return Time.time - pathStartTime;
+				return Time.unscaledTime - pathStartTime;
 			}
 		}
 		Vector2 keysScrollPos;
@@ -1472,7 +1472,7 @@ namespace CameraTools
 			zoomExp = firstFrame.zoom;
 
 			isPlayingPath = true;
-			pathStartTime = Time.time;
+			pathStartTime = Time.unscaledTime;
 		}
 
 		void StopPlayingPath()


### PR DESCRIPTION
Allows paths to play while the game is paused and allows paths to play independent of slow motion rate. Works without moving pathing from FixedUpdate to Update. There don't seem to be any issues with unpaused playback or any change in playback speed when pausing/unpausing during path playback.