### PR TITLE
Quality of Life Tweaks

### DIFF
--- a/CameraTools/CamTools.cs
+++ b/CameraTools/CamTools.cs
@@ -24,7 +24,7 @@ namespace CameraTools
 		Transform origParent;
 		float origNearClip;
 		float origDistance;
-        FlightCamera flightCamera;
+		FlightCamera flightCamera;
 		Part camTarget = null;
 		Vector3 cameraUp = Vector3.up;
 		bool cameraToolActive = false;

--- a/CameraTools/CamTools.cs
+++ b/CameraTools/CamTools.cs
@@ -1869,7 +1869,8 @@ namespace CameraTools
 				}
 			}
 			hasDied = false;
-			if (FlightGlobals.ActiveVessel != null && HighLogic.LoadedScene == GameScenes.FLIGHT && flightCamera.vesselTarget.id != FlightGlobals.ActiveVessel.id)
+			if (FlightGlobals.ActiveVessel != null && HighLogic.LoadedScene == GameScenes.FLIGHT
+				&& flightCamera.vesselTarget != FlightGlobals.ActiveVessel)
 			{
 				flightCamera.SetTarget(FlightGlobals.ActiveVessel.transform, FlightCamera.TargetMode.Vessel);
 			}

--- a/CameraTools/CameraPath.cs
+++ b/CameraTools/CameraPath.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
@@ -51,7 +51,7 @@ namespace CameraTools
 			// Ensure there's a consistent number of entries in the path.
 			while (newPath.positionInterpolationTypes.Count < newPath.points.Count) { newPath.positionInterpolationTypes.Add(PositionInterpolationType.CubicSpline); }
 			while (newPath.rotations.Count < newPath.points.Count) { newPath.rotations.Add(Quaternion.identity); }
-			while (newPath.rotationInterpolationTypes.Count < newPath.points.Count) { newPath.rotationInterpolationTypes.Add(RotationInterpolationType.Slerp); }
+			while (newPath.rotationInterpolationTypes.Count < newPath.points.Count) { newPath.rotationInterpolationTypes.Add(RotationInterpolationType.CubicSpline); }
 			while (newPath.times.Count < newPath.points.Count) { newPath.times.Add(newPath.times.Count); }
 			while (newPath.zooms.Count < newPath.points.Count) { newPath.zooms.Add(1); }
 			newPath.Refresh();


### PR DESCRIPTION
These are a series of tweaks/fixes/new features aimed at improving the user experience and versatility of pathing mode.

- Keys created during path playback are now automatically inserted at the current path time. Useful for molding paths in to specific shapes.

- Added a 'Maintain Speed' button to the keyframe editor that adjusts the duration of the current keyframe to approximately match the speed between the previous two keyframes. Useful for smoothly extending paths and correcting speed inconsistencies in complex paths.

- Camera updates can now be switched between Update or 'Real-time' and FixedUpdate or 'In-Game Time'. 'Real-time' creates smoother paths and works while the game is paused, which helps to reduce lag, while 'In-Game Time' is useful for making sure pathing speed is consistent with game physics and that none of the path is skipped when processing footage to remove lag. See FFmpeg's mpdecimate.

- New keys created while camera tools is inactive are now correctly started at the current camera position, rather than on top of the vessel facing down, or inside the vessel.

- Path playback now starts from the selected keyframe if one is selected. Useful for previewing small changes to long paths.

- The flight camera now correctly reverts to its original distance, orientation and mode when pathing is deactivated.

- Camera zoom is now updated immediately rather than gradually when selecting a keyframe or starting a path.

- NUM7/NUM1 now moves the pathing camera up/down relative to the frame instead of the ground.  This functionality was previously on the scroll wheel. Hold NUM0 to move relative to the ground as before.

- Scroll wheel while using the pathing camera now adjusts move speed. Useful for quickly switching between fine adjustments and repositioning of the camera.

- The default time increment for new keys has been changed back to 10 seconds from 1 second. This is a more practical default path length and makes manually inserting new keys easier.

- The default rotation interpolation mode is now CubicSpline, was previously Slerp.

- Interpolation rate setting renamed to 'Camera Inertia' and the displayed value inverted to try to give the user a more intuitive understanding of what the setting does.

- The last path you used is now remembered between restarts.

- The GUI no longer closes on pressing save. Replaced by a bit of visual feedback. Useful for habitual save pressers. 