### PR TITLE
Tweak Modified Movement & Add Stock Zoom to New Key/Save/Revert

### DIFF
--- a/CameraTools/CamTools.cs
+++ b/CameraTools/CamTools.cs
@@ -1495,7 +1495,7 @@ namespace CameraTools
 			if (!cameraToolActive)
 			{
 				if (flightCamera.FieldOfView != flightCamera.fovDefault)
-                {
+				{
 					zoomFactor = 60 / flightCamera.FieldOfView;
 					zoomExp = Mathf.Log(zoomFactor) + 1f;
 				}


### PR DESCRIPTION
- Tweaked modified movement to move relative to ship orientation instead of the ground; similar functionality when landed and more useful in orbit. 

- Tweaked new key creation to take stock zoom if it is currently adjusted and camera tools is deactivated. Useful for creating a path entirely via control of the stock flight camera.

- Added restoration of stock zoom when camera tools is deactivated.